### PR TITLE
Add option to strip spaces and compress output

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ printer({one: 3, two: 20, three: [9, 3, 2]})
 */
 ```
 
+### Compressing the output
+To compress the output (e.g. to make the resulting PHP as small as possible), use `shortArraySyntax` with `stripSpaces`:
+
+```javascript
+const printer = json2php.make({shortArraySyntax: true, stripSpaces: true})
+printer({
+  arr: [1, 2, 3, 4, 5, {foo: 'surprise!'}],
+  obj: {
+    arr: [{foo: 'bar', bar: 'baz', arr2: [1, 2]}]
+  }
+})
+
+// result:
+// ['arr'=>[1,2,3,4,5,['foo'=>'surprise!']],'obj'=>['arr'=>[['foo'=>'bar','bar'=>'baz','arr2'=>[1,2]]]],'test'=>'str']
+```
+
 ### For Contributors
 
 #### Tests

--- a/src/json2php.coffee
+++ b/src/json2php.coffee
@@ -1,4 +1,4 @@
-make = ({linebreak = '', indent = '', shortArraySyntax = false} = {}) ->
+make = ({linebreak = '', indent = '', shortArraySyntax = false, stripSpaces = false} = {}) ->
   arrOpen = if shortArraySyntax then '[' else 'array('
   arrClose = if shortArraySyntax then ']' else ')'
   nest = {
@@ -8,7 +8,7 @@ make = ({linebreak = '', indent = '', shortArraySyntax = false} = {}) ->
 
     '[object Object]': (obj, parentIndent) ->
       for own key, value of obj
-        transform(key, parentIndent) + ' => ' + transform(value, parentIndent)
+        transform(key, parentIndent) + (if stripSpaces then '=>' else ' => ') + transform(value, parentIndent)
   }
 
   transform = (obj, parentIndent = '') ->
@@ -25,7 +25,7 @@ make = ({linebreak = '', indent = '', shortArraySyntax = false} = {}) ->
         items = nest[objType](obj, nestIndent)
         result = """
           #{arrOpen}#{linebreak + nestIndent}#{
-            items.join(',' + if linebreak == '' then ' ' else linebreak + nestIndent)
+            items.join(',' + if linebreak == '' && !stripSpaces then ' ' else linebreak + nestIndent)
           }#{linebreak + parentIndent}#{arrClose}
         """
       else

--- a/test/json2php_test.coffee
+++ b/test/json2php_test.coffee
@@ -43,3 +43,20 @@ describe 'json2php.make({shortArraySyntax: true})', ->
     pretty = json2php.make({shortArraySyntax: true})
     assert.equal "['a' => 1, 'c' => 'text', 'false' => true, 'undefined' => null]", pretty({ a:1, c:'text', false: true, undefined: null})
     assert.equal '[1, [2], 3]', pretty([1, [2], 3])
+
+describe 'json2php.make({stripSpaces: true})', ->
+  it 'compresses output with shortArraySyntax', ->
+    pretty = json2php.make({stripSpaces: true, shortArraySyntax: true})
+    testObj = {
+      arr: [1, 2, 3, 4, 5, {foo: 'surprise!'}],
+      obj: {
+        arr: [{foo: 'bar', bar: 'baz', arr2: [1, 2]}]
+      },
+      test: 'str'
+    }
+    assert.equal "['arr'=>[1,2,3,4,5,['foo'=>'surprise!']],'obj'=>['arr'=>[['foo'=>'bar','bar'=>'baz','arr2'=>[1,2]]]],'test'=>'str']", pretty(testObj)
+
+  it 'strips spaces from simple arrays and objects', ->
+      pretty = json2php.make({stripSpaces: true})
+      assert.equal "array(1,array(2,4,array('foo'=>'bar','bar'=>'baz')),3)", pretty([1, [2, 4, {foo: "bar", bar: "baz"}], 3])
+


### PR DESCRIPTION
Resolves #15. The new `stripSpaces` option simply avoids printing spaces, and combined with `shortArraySyntax`, you can now compress the size of the PHP output as much as possible.

cc @daniel-zahariev, think this makes sense for the library? Would love to get this in a release :)